### PR TITLE
feat: add @mercuryai/media extension

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,17 +9,6 @@
         "typescript": "^5.6.0",
       },
     },
-    "packages/agent-browser": {
-      "name": "@mercuryai/agent-browser",
-      "version": "0.1.0",
-      "devDependencies": {
-        "bun-types": "latest",
-        "mercury-ai": "0.4.2",
-      },
-      "peerDependencies": {
-        "mercury-ai": ">=0.4.2",
-      },
-    },
     "packages/charts": {
       "name": "@mercuryai/charts",
       "version": "0.1.0",
@@ -31,8 +20,8 @@
         "mercury-ai": ">=0.4.2",
       },
     },
-    "packages/gh": {
-      "name": "@mercuryai/gh",
+    "packages/github": {
+      "name": "@mercuryai/github",
       "version": "0.1.0",
       "devDependencies": {
         "bun-types": "latest",
@@ -42,8 +31,8 @@
         "mercury-ai": ">=0.4.2",
       },
     },
-    "packages/gws": {
-      "name": "@mercuryai/gws",
+    "packages/google-workspace": {
+      "name": "@mercuryai/google-workspace",
       "version": "0.1.0",
       "devDependencies": {
         "bun-types": "latest",
@@ -53,8 +42,8 @@
         "mercury-ai": ">=0.4.2",
       },
     },
-    "packages/napkin-memory": {
-      "name": "@mercuryai/napkin-memory",
+    "packages/knowledge": {
+      "name": "@mercuryai/knowledge",
       "version": "0.1.0",
       "devDependencies": {
         "bun-types": "latest",
@@ -64,8 +53,30 @@
         "mercury-ai": ">=0.4.2",
       },
     },
-    "packages/pdf": {
-      "name": "@mercuryai/pdf",
+    "packages/media": {
+      "name": "@mercuryai/media",
+      "version": "0.1.0",
+      "devDependencies": {
+        "bun-types": "latest",
+        "mercury-ai": "0.4.2",
+      },
+      "peerDependencies": {
+        "mercury-ai": ">=0.4.2",
+      },
+    },
+    "packages/pdf-tools": {
+      "name": "@mercuryai/pdf-tools",
+      "version": "0.1.0",
+      "devDependencies": {
+        "bun-types": "latest",
+        "mercury-ai": "0.4.2",
+      },
+      "peerDependencies": {
+        "mercury-ai": ">=0.4.2",
+      },
+    },
+    "packages/web-browser": {
+      "name": "@mercuryai/web-browser",
       "version": "0.1.0",
       "devDependencies": {
         "bun-types": "latest",
@@ -313,17 +324,19 @@
 
     "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.55.4", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "koffi": "^2.9.0", "marked": "^15.0.12", "mime-types": "^3.0.1" } }, "sha512-LXoa0CV58lEfzbjXyuUMa4KwoPTzTegPZJEEzuc9p7LnlIn4/eBebhTXQmQ7Hxo+/zb3zpy2qoynKpKcEas9GQ=="],
 
-    "@mercuryai/agent-browser": ["@mercuryai/agent-browser@workspace:packages/agent-browser"],
-
     "@mercuryai/charts": ["@mercuryai/charts@workspace:packages/charts"],
 
-    "@mercuryai/gh": ["@mercuryai/gh@workspace:packages/gh"],
+    "@mercuryai/github": ["@mercuryai/github@workspace:packages/github"],
 
-    "@mercuryai/gws": ["@mercuryai/gws@workspace:packages/gws"],
+    "@mercuryai/google-workspace": ["@mercuryai/google-workspace@workspace:packages/google-workspace"],
 
-    "@mercuryai/napkin-memory": ["@mercuryai/napkin-memory@workspace:packages/napkin-memory"],
+    "@mercuryai/knowledge": ["@mercuryai/knowledge@workspace:packages/knowledge"],
 
-    "@mercuryai/pdf": ["@mercuryai/pdf@workspace:packages/pdf"],
+    "@mercuryai/media": ["@mercuryai/media@workspace:packages/media"],
+
+    "@mercuryai/pdf-tools": ["@mercuryai/pdf-tools@workspace:packages/pdf-tools"],
+
+    "@mercuryai/web-browser": ["@mercuryai/web-browser@workspace:packages/web-browser"],
 
     "@mistralai/mistralai": ["@mistralai/mistralai@1.10.0", "", { "dependencies": { "zod": "^3.20.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-tdIgWs4Le8vpvPiUEWne6tK0qbVc+jMenujnvTqOjogrJUsCSQhus0tHTU1avDDh5//Rq2dFgP9mWRAdIEoBqg=="],
 

--- a/packages/media/package.json
+++ b/packages/media/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@mercuryai/media",
+  "version": "0.1.0",
+  "description": "Mercury extension: media processing with ffmpeg, yt-dlp, and imagemagick",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "files": ["dist", "skill"],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "test": "echo 'no tests yet'"
+  },
+  "keywords": ["mercury", "extension"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Michaelliv/mercury-extensions",
+    "directory": "packages/media"
+  },
+  "peerDependencies": {
+    "mercury-ai": ">=0.4.2"
+  },
+  "devDependencies": {
+    "mercury-ai": "0.4.2",
+    "bun-types": "latest"
+  }
+}

--- a/packages/media/skill/SKILL.md
+++ b/packages/media/skill/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: media
+description: Media processing — download, convert, compress, transform audio/video/images using ffmpeg, yt-dlp, and imagemagick
+---
+
+# Media Processing
+
+Three tools for all media work: **ffmpeg** (audio/video), **yt-dlp** (downloads), **imagemagick** (images).
+
+Always output files to `outbox/` so they get delivered back to the user.
+
+## Inspect before processing
+
+```bash
+# Video/audio info
+ffprobe -v quiet -print_format json -show_format -show_streams input.mp4
+
+# Image info
+magick identify -verbose input.jpg
+```
+
+## ffmpeg
+
+### Convert formats
+
+```bash
+ffmpeg -i input.mp4 outbox/output.mp3
+ffmpeg -i input.webm outbox/output.mp4
+ffmpeg -i input.wav outbox/output.flac
+```
+
+### Extract audio
+
+```bash
+ffmpeg -i video.mp4 -vn -acodec libmp3lame -q:a 2 outbox/audio.mp3
+```
+
+### Compress video
+
+```bash
+# General compression (CRF 28 = good balance, higher = smaller/worse)
+ffmpeg -i input.mp4 -crf 28 -preset fast -vf scale=-2:720 outbox/compressed.mp4
+
+# For a specific size target, check output and retry with higher CRF if needed
+ffmpeg -i input.mp4 -crf 32 -preset fast -vf scale=-2:480 outbox/compressed.mp4
+```
+
+### Trim / clip
+
+```bash
+# Fast trim (no re-encode, may have keyframe inaccuracy)
+ffmpeg -i input.mp4 -ss 00:00:30 -to 00:01:00 -c copy outbox/clip.mp4
+
+# Precise trim (re-encodes)
+ffmpeg -i input.mp4 -ss 00:00:30 -to 00:01:00 -c:v libx264 -c:a aac outbox/clip.mp4
+```
+
+### Create GIF
+
+```bash
+ffmpeg -i input.mp4 -ss 0:30 -t 5 -vf "fps=15,scale=480:-1:flags=lanczos" outbox/output.gif
+```
+
+### Strip audio from video
+
+```bash
+ffmpeg -i input.mp4 -an -c:v copy outbox/silent.mp4
+```
+
+### Merge audio + video
+
+```bash
+ffmpeg -i video.mp4 -i audio.mp3 -c:v copy -c:a aac -shortest outbox/merged.mp4
+```
+
+### Concatenate files
+
+```bash
+# Create file list
+printf "file '%s'\n" clip1.mp4 clip2.mp4 clip3.mp4 > /tmp/concat.txt
+ffmpeg -f concat -safe 0 -i /tmp/concat.txt -c copy outbox/joined.mp4
+```
+
+### Generate thumbnail
+
+```bash
+# Single frame at timestamp
+ffmpeg -i input.mp4 -ss 00:00:05 -frames:v 1 outbox/thumb.jpg
+
+# Thumbnail grid (4x4)
+ffmpeg -i input.mp4 -vf "select=not(mod(n\,100)),scale=320:-1,tile=4x4" -frames:v 1 outbox/grid.jpg
+```
+
+### Audio adjustments
+
+```bash
+# Normalize volume
+ffmpeg -i input.mp3 -af loudnorm outbox/normalized.mp3
+
+# Change speed (2x)
+ffmpeg -i input.mp4 -filter:v "setpts=0.5*PTS" -filter:a "atempo=2.0" outbox/fast.mp4
+```
+
+## yt-dlp
+
+### Download video
+
+```bash
+yt-dlp -o "outbox/%(title)s.%(ext)s" "URL"
+```
+
+### Download audio only
+
+```bash
+yt-dlp -x --audio-format mp3 -o "outbox/%(title)s.%(ext)s" "URL"
+```
+
+### Download with size limit
+
+```bash
+# Best format under 16MB (WhatsApp)
+yt-dlp -f "best[filesize<16M]" -o "outbox/%(title)s.%(ext)s" "URL"
+
+# If no single format fits, download best and compress with ffmpeg after
+yt-dlp -o "/tmp/dl.%(ext)s" "URL"
+ffmpeg -i /tmp/dl.* -crf 32 -preset fast -vf scale=-2:480 outbox/compressed.mp4
+```
+
+### List available formats
+
+```bash
+yt-dlp -F "URL"
+```
+
+### Download specific format
+
+```bash
+yt-dlp -f 22 -o "outbox/%(title)s.%(ext)s" "URL"
+```
+
+## imagemagick
+
+### Resize
+
+```bash
+# By width (preserve aspect ratio)
+magick input.jpg -resize 800x outbox/resized.jpg
+
+# By height
+magick input.jpg -resize x600 outbox/resized.jpg
+
+# Exact dimensions (may distort)
+magick input.jpg -resize 800x600! outbox/resized.jpg
+```
+
+### Crop
+
+```bash
+magick input.jpg -crop 500x500+100+50 outbox/cropped.jpg
+```
+
+### Convert format
+
+```bash
+magick input.png outbox/output.jpg
+magick input.jpg outbox/output.webp
+```
+
+### Thumbnail (crop to fill)
+
+```bash
+magick input.jpg -thumbnail 200x200^ -gravity center -extent 200x200 outbox/thumb.jpg
+```
+
+### Composite / overlay
+
+```bash
+magick base.jpg overlay.png -gravity southeast -composite outbox/result.jpg
+```
+
+### Strip metadata
+
+```bash
+magick input.jpg -strip outbox/clean.jpg
+```
+
+### Batch operations
+
+```bash
+# Resize all images in inbox
+for f in inbox/*.jpg; do
+  magick "$f" -resize 800x "outbox/$(basename "$f")"
+done
+```
+
+### Adjust quality
+
+```bash
+# JPEG quality (1-100, lower = smaller)
+magick input.jpg -quality 75 outbox/compressed.jpg
+
+# WebP quality
+magick input.png -quality 80 outbox/output.webp
+```
+
+## Platform size limits
+
+| Platform | Video | Files |
+|----------|-------|-------|
+| WhatsApp | 16 MB | 100 MB |
+| Telegram | 50 MB | 2 GB (bot API) |
+| Discord | 25 MB | 50 MB (Nitro) |
+| Slack | — | 1 GB |
+
+When the user sends media from a platform, check these limits before producing output. If the result exceeds the limit, compress further or split.
+
+## Key rules
+
+1. **Always output to `outbox/`** — this is how files get sent back to the user
+2. **Inspect first** — use `ffprobe` or `magick identify` before processing
+3. **Prefer `-c copy`** when no re-encoding is needed (faster, lossless)
+4. **Check output size** when targeting a size limit — retry with higher CRF / lower resolution if too large
+5. **Use `-y`** flag with ffmpeg to overwrite without prompting: `ffmpeg -y -i ...`
+6. **Input files** arrive in `inbox/` — check there for user-uploaded media

--- a/packages/media/src/index.ts
+++ b/packages/media/src/index.ts
@@ -1,0 +1,27 @@
+import type { MercuryExtensionAPI } from "mercury-ai/extensions/types";
+
+export default function (mercury: {
+  cli(opts: { name: string; install: string }): void;
+  permission(opts: { defaultRoles: string[] }): void;
+  skill(relativePath: string): void;
+}) {
+  mercury.cli({
+    name: "ffmpeg",
+    install:
+      "apt-get update && apt-get install -y --no-install-recommends ffmpeg && rm -rf /var/lib/apt/lists/*",
+  });
+
+  mercury.cli({
+    name: "magick",
+    install:
+      "apt-get update && apt-get install -y --no-install-recommends imagemagick && rm -rf /var/lib/apt/lists/*",
+  });
+
+  mercury.cli({
+    name: "yt-dlp",
+    install: "pip install --break-system-packages yt-dlp",
+  });
+
+  mercury.permission({ defaultRoles: ["admin", "member"] });
+  mercury.skill("./skill");
+}

--- a/packages/media/tsconfig.json
+++ b/packages/media/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "types": ["bun-types"]
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Adds media processing extension with ffmpeg, yt-dlp, and imagemagick.

## What's included
- `packages/media/src/index.ts` — registers 3 CLIs (ffmpeg, magick, yt-dlp) + permission + skill
- `packages/media/skill/SKILL.md` — comprehensive reference for video/audio/image workflows
- Platform size limits (WhatsApp, Telegram, Discord, Slack)

Closes #1